### PR TITLE
Consume buffer before starting

### DIFF
--- a/SourceCode/MacOSX/main.c
+++ b/SourceCode/MacOSX/main.c
@@ -114,6 +114,9 @@ int main(int arg, char *argv[])
 	unsigned char j = 0;
 	for(j=5; j>0; j--)
 	{
+    // Consume buffer
+    char buf[512];
+    read(Cport[0], buf, sizeof(buf));
 	  printf("Remain: %d\n", j);
 	  sleep(1);
 	}


### PR DESCRIPTION
At least ESP8266 does output on UART boot messages.
This makes us skip them, and ensure that everything is consumed ahead.